### PR TITLE
#10 'Create event' button doesn't redirect

### DIFF
--- a/src/pages/LandingPage.py
+++ b/src/pages/LandingPage.py
@@ -7,7 +7,7 @@ class LandingPage(BaseWrapper):
 
     SIGN_IN_UP_BTN_CSS = "#headbtn"
     FIND_EVENT_BTN_CSS = "div.buttons > a"
-    CREATE_EVENT_BTN_CSS = "div.buttons > button"
+    CREATE_EVENT_BTN_XPATH = "//button[contains(text(), 'Create event')]"
     JOIN_EVENTSEXPRESS_BTN_CSS = "div.text-center > div.d-inline-block > button"
     LOG_OUT_BTN_CSS = "div.text-right > div"
     All_PAGE_CSS = "html"
@@ -20,7 +20,7 @@ class LandingPage(BaseWrapper):
         super().__init__(driver)
         self.sign_up_btn = ButtonElement(self.SIGN_IN_UP_BTN_CSS, driver)
         self.find_event_btn = ButtonElement(self.FIND_EVENT_BTN_CSS, driver)
-        self.create_event_btn = ButtonElement(self.CREATE_EVENT_BTN_CSS, driver)
+        self.create_event_btn = ButtonElement(self.CREATE_EVENT_BTN_XPATH, driver)
         self.join_eventsexpress_btn = ButtonElement(self.JOIN_EVENTSEXPRESS_BTN_CSS, driver)
         self.log_out_btn = ButtonElement(self.LOG_OUT_BTN_CSS, driver)
         self.event_express_logo = ButtonElement(self.EVENT_EXPRESS_LOGO_CSS, driver)

--- a/tests/testScripts/test_landing_page_unauth_user.py
+++ b/tests/testScripts/test_landing_page_unauth_user.py
@@ -1,8 +1,9 @@
 """This module contains tests for the landing page of the unauthorized user."""
 
 import allure
+import pytest
 
-import config
+from config import NEW_EMAIL, NEW_PASS
 
 
 @allure.parent_suite('Landing Page')
@@ -13,7 +14,7 @@ def test_landing_a_new_user_can_register(app) -> None:
     expected_result = "Your register was successfull. Please confirm your email."
     app.landing.go_to_site()
     app.landing.sign_up_btn.click_btn_by_css()
-    app.modal.registration(config.NEW_EMAIL, config.NEW_PASS)
+    app.modal.registration(NEW_EMAIL, NEW_PASS)
     assert expected_result == app.modal.get_success_register_text(), \
         "alert message is not the same as expected"
 
@@ -59,4 +60,16 @@ def test_redirects_home_page_after_click_join_event_link(app) -> None:
     app.landing.go_to_site()
     app.landing_authorized_user.wait_explore_more_events_link_clickable()
     app.landing.join_event_link.click_btn_by_xpath()
-    assert expected_result in app.landing_authorized_user.get_home_page_url()
+    with allure.step("Check that the public events appear"):
+        assert expected_result in app.landing_authorized_user.get_home_page_url()
+
+@allure.parent_suite('Landing Page')
+@allure.suite('Unauthorized User')
+@allure.title("Test unauthorized is redirected to the login page after clicking 'Create event' button")
+@pytest.mark.skip(reason="This test is not working: Error 401")
+def test_redirects_to_login_page_after_click_create_event_btn(app) -> None:
+    app.landing.go_to_site()
+    with allure.step("Click 'Create event' button"):
+        app.landing.create_event_btn.click_btn_by_xpath()
+    with allure.step("Check that the login page appears"):
+        pass


### PR DESCRIPTION
Description:
If Registered but not authorized User click on 'Create event' button and then click on 'Log in' button on the pop-up window user should be redirected to 'Log in' page

Expected Result:
The pop-up window appears with the message "Please Log in to the system or create an account" with two buttons "Log in" and "Create new account" below this message